### PR TITLE
chore(a11y): add specific css for externals links

### DIFF
--- a/src/client/src/Pages/Accessibility.tsx
+++ b/src/client/src/Pages/Accessibility.tsx
@@ -82,6 +82,7 @@ function Accessibility() {
                 title="Écrire un message au Défenseur des droits - nouvelle fenêtre"
               >
                 Écrire un message au Défenseur des droits
+                <span className="visually-hidden"> - nouvelle fenêtre</span>
               </a>
             </li>
             <li>
@@ -92,6 +93,7 @@ function Accessibility() {
                 title="Contacter le délégué du Défenseur des droits dans votre région - nouvelle fenêtre"
               >
                 Contacter le délégué du Défenseur des droits dans votre région
+                <span className="visually-hidden"> - nouvelle fenêtre</span>
               </a>
             </li>
             <li>

--- a/src/client/src/Pages/HomeLayout.tsx
+++ b/src/client/src/Pages/HomeLayout.tsx
@@ -130,6 +130,7 @@ function HomeLayout() {
               title="Découvrir la Suite Numérique - nouvelle fenêtre"
             >
               Découvrir la Suite Numérique
+              <span className="visually-hidden"> - nouvelle fenêtre</span>
             </a>
           </div>
         </div>
@@ -218,6 +219,7 @@ function HomeLayout() {
                     title="Annuaire des entreprises - nouvelle fenêtre"
                   >
                     l'Annuaire des Entreprises
+                    <span className="visually-hidden"> - nouvelle fenêtre</span>
                   </a>
                   )
                 </li>
@@ -268,6 +270,7 @@ function HomeLayout() {
                     title="Aide ProConnect - nouvelle fenêtre"
                   >
                     en savoir plus
+                    <span className="visually-hidden"> - nouvelle fenêtre</span>
                   </a>
                   )
                 </li>
@@ -286,6 +289,7 @@ function HomeLayout() {
             title="Voir tous les articles du centre d'aide - nouvelle fenêtre"
           >
             Voir tous les articles du centre d'aide
+            <span className="visually-hidden"> - nouvelle fenêtre</span>
           </a>
         </p>
       </div>

--- a/src/client/src/Pages/Roadmap.tsx
+++ b/src/client/src/Pages/Roadmap.tsx
@@ -90,6 +90,9 @@ function Roadmap() {
                           title="Tchap - nouvelle fenêtre"
                         >
                           Tchap
+                          <span className="visually-hidden">
+                            - nouvelle fenêtre
+                          </span>
                         </a>
                         .
                       </li>
@@ -106,6 +109,9 @@ function Roadmap() {
                           title="Espace Partenaires ProConnect - nouvelle fenêtre"
                         >
                           Espace Partenaires
+                          <span className="visually-hidden">
+                            - nouvelle fenêtre
+                          </span>
                         </a>
                       </li>
                     </ul>

--- a/src/client/src/Pages/layout.css
+++ b/src/client/src/Pages/layout.css
@@ -75,3 +75,28 @@ body {
 .pc-background-alt-blue-france {
   background-color: var(--background-alt-blue-france);
 }
+
+/* For links accessibility */
+/* https://www.ffoodd.fr/masquage-accessible-de-pointe/index.html */
+
+.visually-hidden,
+.visually-hidden-focusable:not(:focus, :focus-within) {
+  border: 0 !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  width: 1px !important;
+  white-space: nowrap !important;
+}
+
+.visually-hidden:not(caption),
+.visually-hidden-focusable:not(caption):not(:focus, :focus-within) {
+  position: absolute !important;
+}
+
+.visually-hidden *,
+.visually-hidden-focusable:not(:focus, :focus-within) * {
+  overflow: hidden !important;
+}

--- a/src/client/src/components/Footer/Footer.tsx
+++ b/src/client/src/components/Footer/Footer.tsx
@@ -29,6 +29,7 @@ function Footer() {
           title="Statuts des services - nouvelle fenêtre"
         >
           Statuts des services
+          <span className="visually-hidden"> - nouvelle fenêtre</span>
         </a>,
         <a
           key="partenaire"
@@ -39,6 +40,7 @@ function Footer() {
           title="Devenez un FI ou FS partenaire - nouvelle fenêtre"
         >
           Devenez un FI ou FS partenaire
+          <span className="visually-hidden"> - nouvelle fenêtre</span>
         </a>,
         headerFooterDisplayItem,
       ]}


### PR DESCRIPTION
Les pictogrammes (carré qui ouvre vers l’extérieur) accolés aux liens qui ouvrent sur une nouvelle fenêtre devraient pouvoir véhiculer la même information si cette page n’a pas de feuille de style activée. 

Ajouter un style visually-hidden masquant l’alternative textuelle du pictogramme est une solution efficace. [Utiliser le masquage accessible de pointe](https://www.ffoodd.fr/masquage-accessible-de-pointe/index.html)